### PR TITLE
Added '=' at beginning of Gravatar tag

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -6,11 +6,11 @@
 		This is the home page for the UofT Course Info Project
 		</h2>
 
-		 <% if user_signed_in? %>
-		<% gravatar_for current_user %>
-		Logged in as <strong><%= current_user.email %></strong>.
-		<%= link_to 'Edit profile', edit_user_registration_path, :class => 'navbar-link' %> |
-		<%= link_to "Logout", destroy_user_session_path, method: :delete, :class => 'navbar-link' %>
+		<% if user_signed_in? %>
+			<%= gravatar_for current_user %>
+			Logged in as <strong><%= current_user.email %></strong>.
+			<%= link_to 'Edit profile', edit_user_registration_path, :class => 'navbar-link' %> |
+			<%= link_to "Logout", destroy_user_session_path, method: :delete, :class => 'navbar-link' %>
 		<% end -%>
 	</div>
 </section>


### PR DESCRIPTION
The equals sign was missing at the beginning of the tag so the result of
the call to the `gravatar_for` helper was not outputted in the final
HTML document.

No need for review.