### PR TITLE
Fixed bug in rendering course page with comments

### DIFF
--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -20,7 +20,7 @@
           <p>
             <%= comment.body %>
           </p>
-          <% if current_user.id == comment.user_id %>
+          <% if user_signed_in? && current_user.id == comment.user_id %>
             <td><%= link_to 'Edit', edit_course_comment_path(@course, comment) %></td>
           <% end %>
           <td><%= link_to 'Reply', course_comment_path(@course, comment) %></td>


### PR DESCRIPTION
- If a user who is not logged in tried to view a course, they would
receive an error because the code was trying to check whether the
current user was the author a comment, while the current user was
```Nil```.
- I simply add a preceeding condition that checked if the user is signed
in or not